### PR TITLE
Added a configurable value for the SSH poll timeout

### DIFF
--- a/mvpnet/fdio_thread.c
+++ b/mvpnet/fdio_thread.c
@@ -150,8 +150,8 @@ static void *fdio_sshprobe(void *arg) {
     struct pollfd pf;
     char line[128];
 
-    note = FDIO_NOTE_NOSSHD;   /* default is to fail... */
-    ms_left = 60 * 1000;       /* wait up to 60 seconds for sshd */
+    note = FDIO_NOTE_NOSSHD;               /* default is to fail... */
+    ms_left = a->sshprobe_timeout * 1000;  /* timeout (cvt from secs) */
 
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -864,6 +864,8 @@ void *fdio_main(void *arg) {
      * if we can connect to the guest's sshd and get a sshd banner, then
      * we consider the guest fully booted.
      */
+    mlog(FDIO_INFO, "launching sshprobe thread (localport=%d, timeout=%d)",
+        a->localsshport, a->sshprobe_timeout);
     ret = pthread_create(&sshprobe.pth, NULL, fdio_sshprobe, a);
     if (ret != 0) {
         mlog(FDIO_CRIT, "main: pthread_create sshprobe failed (%d)", ret);

--- a/mvpnet/fdio_thread.h
+++ b/mvpnet/fdio_thread.h
@@ -95,6 +95,7 @@ struct fdio_args {
     struct strvec *qvec;     /* qemu command line for exec */
     struct mpiinfo mi;       /* copy of mpi info for this proc */
     int localsshport;        /* local port to reach guest sshd on */
+    int sshprobe_timeout;    /* timeout for ssh probe (secs) */
     int nettype;             /* network type (SOCK_STREAM or SOCK_DGRAM) */
     char **socknames;        /* unix domain socket filenames */
     int *sockfds;            /* socket file descriptors */

--- a/mvpnet/mvpnet.c
+++ b/mvpnet/mvpnet.c
@@ -200,6 +200,8 @@ void usage(char *prog, int rank) {
     fprintf(stderr, "\t-S [pri]    mlog stderr priority (def=%s)\n",
             defs.stderrpri_ml);
     fprintf(stderr, "\t-t [dir]    tftp dir (enables tftpd)\n");
+    fprintf(stderr, "\t-T [sec]    sshd start probe timeout (secs, def=%d)\n",
+            defs.sshprobe_timeout);
     fprintf(stderr, "\t-u [usr]    username on guest (for ssh)\n");
     fprintf(stderr, "\t-w [val]   *wrapper log on (1) or off (0) (def=%d)\n",
             defs.wraplog);
@@ -271,7 +273,7 @@ int main(int argc, char **argv) {
 
     /* parse our command line options */
     while ((ch = getopt(argc, argv,
-                 "B:c:C:d:D:ghi:j:k:l:L:m:M:n:p:q:r:s:S:t:u:w:X:")) != -1) {
+                 "B:c:C:d:D:ghi:j:k:l:L:m:M:n:p:q:r:s:S:t:T:u:w:X:")) != -1) {
         switch (ch) {
         case 'B':
             match = prefix_num_match(optarg, ':', mii.rank, &optrest);
@@ -427,6 +429,12 @@ int main(int argc, char **argv) {
                 rmerror(mii.rank, 0, "tftpdir: %s: bad stringcheck",
                         mopt.tftpdir);
             break;
+	case 'T':
+            mopt.sshprobe_timeout = atoi(optarg);
+            if (mopt.sshprobe_timeout < 1)
+                rmerror(mii.rank, 0, "sshprobe_timeout: %s: invalid arg",
+                        optarg);
+	    break;
         case 'u':
             mopt.username = optarg;
             for (cp = optarg ; *cp ; cp++) {
@@ -597,6 +605,7 @@ int main(int argc, char **argv) {
     if (mopt.rundir)
         mlog(MVP_NOTE, "rundir: %s", mopt.rundir);
     mlog(MVP_NOTE, "localport: %d", localport);
+    mlog(MVP_NOTE, "sshprobe_timeout: %d", mopt.sshprobe_timeout);
     if (qemuvec.base == NULL) {
         mlog(MVP_NOTE, "qemuvec: <null>");
     } else {
@@ -643,6 +652,7 @@ int main(int argc, char **argv) {
     fdioargs.qvec = &qemuvec;
     fdioargs.mi = mii;     /* struct copy */
     fdioargs.localsshport = localport;
+    fdioargs.sshprobe_timeout = mopt.sshprobe_timeout;
     fdioargs.nettype = mopt.nettype;
     fdioargs.socknames = socknames;
     fdioargs.sockfds = sockfds;

--- a/mvpnet/mvpnet.h
+++ b/mvpnet/mvpnet.h
@@ -63,9 +63,10 @@ struct mvpopts {
     char *qemucmd;         /* qemu command */
     char *rundir;          /* runtime directory to copy image to */
     char *sockdir;         /* directory to put sockets in */
+    int sshprobe_timeout;  /* ssh probe timeout (secs) */
+    char *stderrpri_ml;    /* stderr mlog priority */
     char *tftpdir;         /* tftp dir (enables tftpd) */
     char *username;        /* username to login to on guest */
-    char *stderrpri_ml;    /* stderr mlog priority */
     int wraplog;           /* enable monwrap log file */
     char *xmask_ml;        /* mlog mask */
 };
@@ -77,7 +78,7 @@ struct mvpopts {
         .image = STRVEC_INIT, .kvm = 1, .logdir = "/tmp", .mem_mb = 4096,      \
         .monwrap = "monwrap", .nettype = SOCK_STREAM,                          \
         .processor = "host", .qemucmd = "qemu-system-x86_64",                  \
-        .sockdir = "/tmp", .stderrpri_ml = "CRIT"                              \
+        .sockdir = "/tmp", .sshprobe_timeout = 90, .stderrpri_ml = "CRIT"      \
     }
 
 /* struct to track if a pthread is running */


### PR DESCRIPTION
The default of 60 seconds wasn't long enough in my testing. So now it is configurable.