### PR TITLE
Adjust mvpnet host IP addressing scheme

### DIFF
--- a/docs/cloud-init.md
+++ b/docs/cloud-init.md
@@ -96,10 +96,10 @@ the other VMs in this MPI job can be accessed over the mvpnet (10.0.0.0/8):
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 #wsize: 4
-10.0.0.0 n0000
-10.0.0.1 n0001
-10.0.0.2 n0002
-10.0.0.3 n0003
+10.0.0.1 n0000
+10.0.0.2 n0001
+10.0.0.3 n0002
+10.0.0.4 n0003
 [root@n0000 ~]# ssh n0003
 Warning: Permanently added 'n0003' (ED25519) to the list of known hosts.
 Activate the web console with: systemctl enable --now cockpit.socket

--- a/docs/manual-image.md
+++ b/docs/manual-image.md
@@ -83,14 +83,14 @@ On the rank 0 guest, get a root shell and bring up the ens3 interface:
 % ssh -p 2201 localhost
 ...
 :~$ sudo -H /bin/bash
-# ip addr add 10.0.0.0/8 dev ens3
+# ip addr add 10.0.0.1/8 broadcast 10.255.255.255 dev ens3
 # ip link set ens3 up
 </pre>
 
-On the rank 1 guest, repeat the above with the address 10.0.0.1/8 instead
-of 10.0.0.0.
+On the rank 1 guest, repeat the above with the address 10.0.0.2/8 instead
+of 10.0.0.1.
 
-XXX: ssh keys not right for logging in between 10.0.0.0 and 10.0.0.1.
+XXX: ssh keys not right for logging in between 10.0.0.1 and 10.0.0.2.
 ssh will connect over the MPI network, but you will not be able to login.
 
 To shutdown the mvpnet demo you must halt and power off both VMs.

--- a/mvpnet/fdio_thread.c
+++ b/mvpnet/fdio_thread.c
@@ -282,12 +282,13 @@ static void fdio_process_qframe(struct fbuf *fbuf, char *fstart, int nbytes,
      * case 2: broadcast ARP request.  we can directly answer these
      * since we know the mapping from MPI rank to IP and ethernet addrs.
      */
-    if ((arp_qrank = pktfmt_arp_req_qrank(efrm, nbytes - xtrahdrsz)) != -1) {
+    if (pktfmt_arp_req_qrank(efrm, nbytes - xtrahdrsz, &arp_qrank) != -1) {
         void *rep_fstart;
         struct fbuf *rep_fbuf;
         uint8_t *rep_frm;
 
-        if (arp_qrank >= a->mi.wsize || arp_qrank == a->mi.rank) {
+        if (arp_qrank < 0 || arp_qrank >= a->mi.wsize ||
+            arp_qrank == a->mi.rank) {
             a->fst.arpreq_badreq++;
             mlog(FDIO_INFO, "pqframe: bad bcast-ARP for %d, drop!", arp_qrank);
             return;  /* drop req if unknown rank or for self */

--- a/mvpnet/pktfmt.h
+++ b/mvpnet/pktfmt.h
@@ -47,7 +47,7 @@
 #define ETH_TYPEOFF  (ETH_ADDRSIZE*2)    /* ethernet frame type offset */
 #define ETH_DATAOFF  (ETH_TYPEOFF+2)     /* data offset */
 
-int pktfmt_arp_req_qrank(uint8_t *ef, int efsz);
+int pktfmt_arp_req_qrank(uint8_t *ef, int efsz, int *qrankp);
 void pktfmt_arp_mkreply(uint8_t *req, int qrank, uint8_t *rep);
 
 #endif /* MVP_PKTFMT_H */


### PR DESCRIPTION
These changes modify  the mvpnet host IP addressing scheme to start at 1, not 0.

Some older Linux kernels have significant problems using a network address, e.g., 10.0.0.0/8, as a host IP address - they consistently treat it as a broadcast address even when explicitly told otherwise.

These kernels are still maintained and widely used, so these changes work around the problem by making our host numbering start at .1 to accommodate them.

previously, the host mapping on the mvpnet would be like:
10.0.0.0 n0000
10.0.0.1 n0001
10.0.0.2 n0002
...

now, we have:
10.0.0.1 n0000
10.0.0.2 n0001
10.0.0.3 n0002
...

Addresses #4.
